### PR TITLE
fix 404 on nav bar bug

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -18,7 +18,7 @@
           <a href={{ '/'|url }}>/home/{{config.THEME_SETTINGS.headerusername}}</a>
         </li>
         {% for page in site.query('/') %}
-        {% if page.path != '/404' %}
+        {% if page.path != '/404.html' %}
         <li >
           <a href="{{page.url_path | url }}">~{{ page.path }}</a>
         </li>


### PR DESCRIPTION
Hi,
I found an bug.
From README.md, we need to create a `404.html/contents.lr` to access 404 page. This commit fix `~/404.html` shows in nav bar.

## before

![before](https://user-images.githubusercontent.com/5977351/65392178-5dd31380-dda4-11e9-9b5b-767d19bc6d61.png)


## after

![after](https://user-images.githubusercontent.com/5977351/65392135-fd43d680-dda3-11e9-8a3d-4925f31d984d.png)
